### PR TITLE
feat: Marker 중심 ERD 재설계 및 DB 스키마 수정

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { databaseConfig } from './database.config';
 import { UserModule } from './user/user.module';
 import { ImageModule } from './image/image.module';
 import { ReportModule } from './report/report.module';
+import { SafetyMungoReportModule } from './safety-mungo-report/safety-mungo-report.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { ReportModule } from './report/report.module';
     AuthModule,
     ImageModule,
     ReportModule,
+    SafetyMungoReportModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { UserModule } from './user/user.module';
 import { ImageModule } from './image/image.module';
 import { ReportModule } from './report/report.module';
 import { SafetyMungoReportModule } from './safety-mungo-report/safety-mungo-report.module';
+import { MarkerModule } from './marker/marker.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { SafetyMungoReportModule } from './safety-mungo-report/safety-mungo-repo
     ImageModule,
     ReportModule,
     SafetyMungoReportModule,
+    MarkerModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/comment/entities/comment.entity.ts
+++ b/src/comment/entities/comment.entity.ts
@@ -5,7 +5,7 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { Report } from '../../report/entities/report.entity';
+import { Marker } from '../../marker/entities/marker.entity';
 import { User } from '../../user/entities/user.entity';
 
 @Entity('comments')
@@ -14,7 +14,7 @@ export class Comment {
   id: string;
 
   @Column()
-  reportId: string;
+  markerId: string;
 
   @Column()
   userId: string;
@@ -25,8 +25,8 @@ export class Comment {
   @CreateDateColumn()
   createdAt: Date;
 
-  @ManyToOne(() => Report, (report) => report.comments, { onDelete: 'CASCADE' })
-  report: Report;
+  @ManyToOne(() => Marker, (marker) => marker.comments, { onDelete: 'CASCADE' })
+  marker: Marker;
 
   @ManyToOne(() => User, (user) => user.comments)
   user: User;

--- a/src/image/dto/save-image.dto.ts
+++ b/src/image/dto/save-image.dto.ts
@@ -1,4 +1,4 @@
-import { IsIn, IsInt, IsUrl, Max, Min } from 'class-validator';
+import { IsIn, IsInt, IsUUID, IsUrl, Max, Min } from 'class-validator';
 
 const ALLOWED_MIME_TYPES = [
   'image/jpeg',
@@ -8,6 +8,9 @@ const ALLOWED_MIME_TYPES = [
 ] as const;
 
 export class SaveImageDto {
+  @IsUUID()
+  reportId: string;
+
   @IsUrl()
   url: string;
 

--- a/src/image/entities/image.entity.ts
+++ b/src/image/entities/image.entity.ts
@@ -2,13 +2,18 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import { Report } from '../../report/entities/report.entity';
 
-@Entity()
+@Entity('images')
 export class Image {
-  @PrimaryGeneratedColumn()
-  id: number;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  reportId: string;
 
   @Column()
   url: string;
@@ -16,9 +21,12 @@ export class Image {
   @Column()
   mimeType: string;
 
-  @Column()
-  size: number;
+  @Column({ nullable: true })
+  size: number | null;
 
   @CreateDateColumn()
   createdAt: Date;
+
+  @ManyToOne(() => Report, (report) => report.images, { onDelete: 'CASCADE' })
+  report: Report;
 }

--- a/src/image/entities/image.entity.ts
+++ b/src/image/entities/image.entity.ts
@@ -21,7 +21,7 @@ export class Image {
   @Column()
   mimeType: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'int', nullable: true })
   size: number | null;
 
   @CreateDateColumn()

--- a/src/image/image.controller.ts
+++ b/src/image/image.controller.ts
@@ -3,7 +3,7 @@ import {
   Controller,
   Get,
   Param,
-  ParseIntPipe,
+  ParseUUIDPipe,
   Post,
   UseGuards,
 } from '@nestjs/common';
@@ -35,7 +35,7 @@ export class ImageController {
 
   @Get(':id')
   @ApiOperation({ summary: '이미지 단건 조회' })
-  findOne(@Param('id', ParseIntPipe) id: number): Promise<Image> {
+  findOne(@Param('id', ParseUUIDPipe) id: string): Promise<Image> {
     return this.imageService.findOne(id);
   }
 

--- a/src/image/image.service.ts
+++ b/src/image/image.service.ts
@@ -42,6 +42,7 @@ export class ImageService {
     }
 
     const image = this.imageRepository.create({
+      reportId: dto.reportId,
       url: dto.url,
       mimeType: dto.mimeType,
       size: dto.size,
@@ -50,7 +51,7 @@ export class ImageService {
     return this.imageRepository.save(image);
   }
 
-  async findOne(id: number): Promise<Image> {
+  async findOne(id: string): Promise<Image> {
     const image = await this.imageRepository.findOneBy({ id });
     if (!image) {
       throw new NotFoundException(`Image with id ${id} not found`);

--- a/src/like/entities/like.entity.ts
+++ b/src/like/entities/like.entity.ts
@@ -6,17 +6,17 @@ import {
   PrimaryGeneratedColumn,
   Unique,
 } from 'typeorm';
-import { Report } from '../../report/entities/report.entity';
+import { Marker } from '../../marker/entities/marker.entity';
 import { User } from '../../user/entities/user.entity';
 
-@Unique(['reportId', 'userId'])
+@Unique(['markerId', 'userId'])
 @Entity('likes')
 export class Like {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
   @Column()
-  reportId: string;
+  markerId: string;
 
   @Column()
   userId: string;
@@ -24,8 +24,8 @@ export class Like {
   @CreateDateColumn()
   createdAt: Date;
 
-  @ManyToOne(() => Report, (report) => report.likes, { onDelete: 'CASCADE' })
-  report: Report;
+  @ManyToOne(() => Marker, (marker) => marker.likes, { onDelete: 'CASCADE' })
+  marker: Marker;
 
   @ManyToOne(() => User, (user) => user.likes)
   user: User;

--- a/src/marker/entities/marker.entity.ts
+++ b/src/marker/entities/marker.entity.ts
@@ -2,9 +2,12 @@ import {
   Column,
   Entity,
   JoinColumn,
+  OneToMany,
   OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import { Comment } from '../../comment/entities/comment.entity';
+import { Like } from '../../like/entities/like.entity';
 import { HazardLevel, Report } from '../../report/entities/report.entity';
 import { SafetyMungoReport } from '../../safety-mungo-report/entities/safety-mungo-report.entity';
 
@@ -46,4 +49,10 @@ export class Marker {
   @OneToOne(() => SafetyMungoReport, (smr) => smr.marker)
   @JoinColumn({ name: 'safetyMungoReportId' })
   safetyMungoReport: SafetyMungoReport | null;
+
+  @OneToMany(() => Comment, (comment) => comment.marker)
+  comments: Comment[];
+
+  @OneToMany(() => Like, (like) => like.marker)
+  likes: Like[];
 }

--- a/src/marker/entities/marker.entity.ts
+++ b/src/marker/entities/marker.entity.ts
@@ -1,5 +1,6 @@
 import {
   Column,
+  CreateDateColumn,
   Entity,
   JoinColumn,
   OneToMany,
@@ -55,4 +56,7 @@ export class Marker {
 
   @OneToMany(() => Like, (like) => like.marker)
   likes: Like[];
+
+  @CreateDateColumn()
+  createdAt: Date;
 }

--- a/src/marker/entities/marker.entity.ts
+++ b/src/marker/entities/marker.entity.ts
@@ -1,0 +1,49 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { HazardLevel, Report } from '../../report/entities/report.entity';
+import { SafetyMungoReport } from '../../safety-mungo-report/entities/safety-mungo-report.entity';
+
+@Entity('markers')
+export class Marker {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ nullable: true, unique: true })
+  reportId: string | null;
+
+  @Column({ nullable: true, unique: true })
+  safetyMungoReportId: string | null;
+
+  @Column('decimal', { precision: 10, scale: 7 })
+  latitude: number;
+
+  @Column('decimal', { precision: 10, scale: 7 })
+  longitude: number;
+
+  @Column({
+    type: 'geometry',
+    spatialFeatureType: 'Point',
+    srid: 4326,
+    nullable: true,
+  })
+  location: string | null;
+
+  @Column()
+  hazardType: string;
+
+  @Column({ type: 'enum', enum: HazardLevel, nullable: true })
+  hazardLevel: HazardLevel | null;
+
+  @OneToOne(() => Report, (report) => report.marker)
+  @JoinColumn({ name: 'reportId' })
+  report: Report | null;
+
+  @OneToOne(() => SafetyMungoReport, (smr) => smr.marker)
+  @JoinColumn({ name: 'safetyMungoReportId' })
+  safetyMungoReport: SafetyMungoReport | null;
+}

--- a/src/marker/entities/marker.entity.ts
+++ b/src/marker/entities/marker.entity.ts
@@ -7,6 +7,11 @@ import {
   OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+
+export enum MarkerSource {
+  REPORT = 'report',
+  SAFETY_MUNGO = 'safety_mungo_report',
+}
 import { Comment } from '../../comment/entities/comment.entity';
 import { Like } from '../../like/entities/like.entity';
 import { HazardLevel, Report } from '../../report/entities/report.entity';
@@ -22,6 +27,9 @@ export class Marker {
 
   @Column({ nullable: true, unique: true })
   safetyMungoReportId: string | null;
+
+  @Column({ type: 'enum', enum: MarkerSource })
+  source: MarkerSource;
 
   @Column('decimal', { precision: 10, scale: 7 })
   latitude: number;

--- a/src/marker/marker.module.ts
+++ b/src/marker/marker.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Marker } from './entities/marker.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Marker])],
+})
+export class MarkerModule {}

--- a/src/migrations/1771742593598-CreateImageTable.ts
+++ b/src/migrations/1771742593598-CreateImageTable.ts
@@ -1,14 +1,25 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class CreateImageTable1771742593598 implements MigrationInterface {
-    name = 'CreateImageTable1771742593598'
+  name = 'CreateImageTable1771742593598';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE "image" ("id" SERIAL NOT NULL, "url" character varying NOT NULL, "mimeType" character varying NOT NULL, "size" integer NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_d6db1ab4ee9ad9dbe86c64e4cc3" PRIMARY KEY ("id"))`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "images" (
+        "id"        UUID      NOT NULL DEFAULT gen_random_uuid(),
+        "reportId"  UUID      NOT NULL,
+        "url"       VARCHAR   NOT NULL,
+        "mimeType"  VARCHAR   NOT NULL,
+        "size"      BIGINT,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_images" PRIMARY KEY ("id"),
+        -- 신고 삭제 시 이미지도 함께 삭제
+        CONSTRAINT "FK_images_reportId" FOREIGN KEY ("reportId") REFERENCES "reports"("id") ON DELETE CASCADE
+      )
+    `);
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`DROP TABLE "image"`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "images"`);
+  }
 }

--- a/src/migrations/1772496001000-CreateReportsTable.ts
+++ b/src/migrations/1772496001000-CreateReportsTable.ts
@@ -12,31 +12,22 @@ export class CreateReportsTable1772496001000 implements MigrationInterface {
 
     await queryRunner.query(`
       CREATE TABLE "reports" (
-        "id"           UUID        NOT NULL DEFAULT gen_random_uuid(),
-        "userId"       UUID        NOT NULL,
-        "imageUrl"     VARCHAR     NOT NULL,
-        "latitude"     DECIMAL(10, 7) NOT NULL,
-        "longitude"    DECIMAL(10, 7) NOT NULL,
-        "location"     GEOMETRY(Point, 4326),
-        "hazardType"   VARCHAR     NOT NULL,
+        "id"           UUID         NOT NULL DEFAULT gen_random_uuid(),
+        "userId"       UUID         NOT NULL,
+        "hazardType"   VARCHAR      NOT NULL,
         "hazardLevel"  hazard_level NOT NULL,
-        "description"  TEXT        NOT NULL,
+        "description"  TEXT         NOT NULL,
         "aiRawResult"  JSONB,
-        "createdAt"    TIMESTAMP   NOT NULL DEFAULT now(),
-        "updatedAt"    TIMESTAMP   NOT NULL DEFAULT now(),
+        "createdAt"    TIMESTAMP    NOT NULL DEFAULT now(),
+        "updatedAt"    TIMESTAMP    NOT NULL DEFAULT now(),
         CONSTRAINT "PK_reports" PRIMARY KEY ("id"),
         -- 유저 탈퇴 시 신고 데이터 보존: ON DELETE CASCADE 미적용
         CONSTRAINT "FK_reports_userId" FOREIGN KEY ("userId") REFERENCES "users"("id")
       )
     `);
-
-    await queryRunner.query(
-      `CREATE INDEX "IDX_reports_location" ON "reports" USING GIST ("location")`,
-    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX "IDX_reports_location"`);
     await queryRunner.query(`DROP TABLE "reports"`);
     await queryRunner.query(`DROP TYPE hazard_level`);
   }

--- a/src/migrations/1772496002000-CreateCommentsTable.ts
+++ b/src/migrations/1772496002000-CreateCommentsTable.ts
@@ -7,13 +7,13 @@ export class CreateCommentsTable1772496002000 implements MigrationInterface {
     await queryRunner.query(`
       CREATE TABLE "comments" (
         "id"        UUID      NOT NULL DEFAULT gen_random_uuid(),
-        "reportId"  UUID      NOT NULL,
+        "markerId"  UUID      NOT NULL,
         "userId"    UUID      NOT NULL,
         "content"   TEXT      NOT NULL,
         "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
         CONSTRAINT "PK_comments" PRIMARY KEY ("id"),
-        -- 신고 삭제 시 댓글도 함께 삭제 (명세서 ON DELETE CASCADE 요구사항)
-        CONSTRAINT "FK_comments_reportId" FOREIGN KEY ("reportId") REFERENCES "reports"("id") ON DELETE CASCADE,
+        -- 마커 삭제 시 댓글도 함께 삭제
+        CONSTRAINT "FK_comments_markerId" FOREIGN KEY ("markerId") REFERENCES "markers"("id") ON DELETE CASCADE,
         -- 유저 탈퇴 시 댓글 데이터 보존: ON DELETE CASCADE 미적용
         CONSTRAINT "FK_comments_userId" FOREIGN KEY ("userId") REFERENCES "users"("id")
       )

--- a/src/migrations/1772496003000-CreateLikesTable.ts
+++ b/src/migrations/1772496003000-CreateLikesTable.ts
@@ -7,16 +7,16 @@ export class CreateLikesTable1772496003000 implements MigrationInterface {
     await queryRunner.query(`
       CREATE TABLE "likes" (
         "id"        UUID      NOT NULL DEFAULT gen_random_uuid(),
-        "reportId"  UUID      NOT NULL,
+        "markerId"  UUID      NOT NULL,
         "userId"    UUID      NOT NULL,
         "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
         CONSTRAINT "PK_likes" PRIMARY KEY ("id"),
-        -- 신고 삭제 시 공감도 함께 삭제 (명세서 ON DELETE CASCADE 요구사항)
-        CONSTRAINT "FK_likes_reportId" FOREIGN KEY ("reportId") REFERENCES "reports"("id") ON DELETE CASCADE,
+        -- 마커 삭제 시 공감도 함께 삭제
+        CONSTRAINT "FK_likes_markerId" FOREIGN KEY ("markerId") REFERENCES "markers"("id") ON DELETE CASCADE,
         -- 유저 탈퇴 시 공감 데이터 보존: ON DELETE CASCADE 미적용
         CONSTRAINT "FK_likes_userId" FOREIGN KEY ("userId") REFERENCES "users"("id"),
-        -- DB 레벨 중복 공감 차단 (엔티티의 @Unique(['reportId', 'userId'])와 대응)
-        CONSTRAINT "UQ_likes_reportId_userId" UNIQUE ("reportId", "userId")
+        -- DB 레벨 중복 공감 차단 (엔티티의 @Unique(['markerId', 'userId'])와 대응)
+        CONSTRAINT "UQ_likes_markerId_userId" UNIQUE ("markerId", "userId")
       )
     `);
   }

--- a/src/migrations/1772496004000-CreateSafetyMungoReportsTable.ts
+++ b/src/migrations/1772496004000-CreateSafetyMungoReportsTable.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateSafetyMungoReportsTable1772496004000
+  implements MigrationInterface
+{
+  name = 'CreateSafetyMungoReportsTable1772496004000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "safety_mungo_reports" (
+        "externalReportId" VARCHAR          NOT NULL,
+        "externalId"       VARCHAR,
+        "spotName"         VARCHAR,
+        "category"         VARCHAR,
+        "description"      TEXT,
+        "origin"           VARCHAR,
+        "occurenceDate"    DATE,
+        "syncedAt"         TIMESTAMP,
+        CONSTRAINT "PK_safety_mungo_reports" PRIMARY KEY ("externalReportId")
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "safety_mungo_reports"`);
+  }
+}

--- a/src/migrations/1772496005000-CreateMarkersTable.ts
+++ b/src/migrations/1772496005000-CreateMarkersTable.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateMarkersTable1772496005000 implements MigrationInterface {
+  name = 'CreateMarkersTable1772496005000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "markers" (
+        "id"                   UUID          NOT NULL DEFAULT gen_random_uuid(),
+        -- 마커 출처가 사용자 신고인 경우에만 존재, UNIQUE로 1:1 보장
+        "reportId"             UUID          UNIQUE,
+        -- 마커 출처가 안전신문고인 경우에만 존재, UNIQUE로 1:1 보장
+        "safetyMungoReportId"  VARCHAR       UNIQUE,
+        "latitude"             DECIMAL(10,7) NOT NULL,
+        "longitude"            DECIMAL(10,7) NOT NULL,
+        -- lat/lng 기반 공간 인덱스용, 별도 계산 시점이 있으므로 nullable
+        "location"             GEOMETRY(Point, 4326),
+        "hazardType"           VARCHAR       NOT NULL,
+        -- 안전신문고 출처 마커는 위험 등급 정보가 없으므로 nullable
+        "hazardLevel"          hazard_level,
+        CONSTRAINT "PK_markers" PRIMARY KEY ("id"),
+        -- 신고 삭제 시 마커도 함께 삭제 (댓글, 공감 cascade로 연쇄 삭제됨)
+        CONSTRAINT "FK_markers_reportId"
+          FOREIGN KEY ("reportId") REFERENCES "reports"("id") ON DELETE CASCADE,
+        -- 외부 데이터 삭제 시 마커도 함께 삭제
+        CONSTRAINT "FK_markers_safetyMungoReportId"
+          FOREIGN KEY ("safetyMungoReportId") REFERENCES "safety_mungo_reports"("externalReportId") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "IDX_markers_location" ON "markers" USING GIST ("location")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_markers_location"`);
+    await queryRunner.query(`DROP TABLE "markers"`);
+  }
+}

--- a/src/migrations/1772496005000-CreateMarkersTable.ts
+++ b/src/migrations/1772496005000-CreateMarkersTable.ts
@@ -4,6 +4,10 @@ export class CreateMarkersTable1772496005000 implements MigrationInterface {
   name = 'CreateMarkersTable1772496005000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "marker_source" AS ENUM ('report', 'safety_mungo_report')`,
+    );
+
     await queryRunner.query(`
       CREATE TABLE "markers" (
         "id"                   UUID          NOT NULL DEFAULT gen_random_uuid(),
@@ -15,6 +19,7 @@ export class CreateMarkersTable1772496005000 implements MigrationInterface {
         "longitude"            DECIMAL(10,7) NOT NULL,
         -- lat/lng 기반 공간 인덱스용, 별도 계산 시점이 있으므로 nullable
         "location"             GEOMETRY(Point, 4326),
+        "source"               marker_source NOT NULL,
         "hazardType"           VARCHAR       NOT NULL,
         -- 안전신문고 출처 마커는 위험 등급 정보가 없으므로 nullable
         "hazardLevel"          hazard_level,
@@ -37,5 +42,6 @@ export class CreateMarkersTable1772496005000 implements MigrationInterface {
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`DROP INDEX "IDX_markers_location"`);
     await queryRunner.query(`DROP TABLE "markers"`);
+    await queryRunner.query(`DROP TYPE "marker_source"`);
   }
 }

--- a/src/migrations/1772496005000-CreateMarkersTable.ts
+++ b/src/migrations/1772496005000-CreateMarkersTable.ts
@@ -18,6 +18,7 @@ export class CreateMarkersTable1772496005000 implements MigrationInterface {
         "hazardType"           VARCHAR       NOT NULL,
         -- 안전신문고 출처 마커는 위험 등급 정보가 없으므로 nullable
         "hazardLevel"          hazard_level,
+        "createdAt"            TIMESTAMPTZ   NOT NULL DEFAULT now(),
         CONSTRAINT "PK_markers" PRIMARY KEY ("id"),
         -- 신고 삭제 시 마커도 함께 삭제 (댓글, 공감 cascade로 연쇄 삭제됨)
         CONSTRAINT "FK_markers_reportId"

--- a/src/migrations/1772496006000-CreateImagesTable.ts
+++ b/src/migrations/1772496006000-CreateImagesTable.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class CreateImageTable1771742593598 implements MigrationInterface {
-  name = 'CreateImageTable1771742593598';
+export class CreateImagesTable1772496006000 implements MigrationInterface {
+  name = 'CreateImagesTable1772496006000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`

--- a/src/migrations/1772496006000-CreateImagesTable.ts
+++ b/src/migrations/1772496006000-CreateImagesTable.ts
@@ -10,7 +10,7 @@ export class CreateImagesTable1772496006000 implements MigrationInterface {
         "reportId"  UUID      NOT NULL,
         "url"       VARCHAR   NOT NULL,
         "mimeType"  VARCHAR   NOT NULL,
-        "size"      BIGINT,
+        "size"      INTEGER,
         "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
         CONSTRAINT "PK_images" PRIMARY KEY ("id"),
         -- 신고 삭제 시 이미지도 함께 삭제

--- a/src/migrations/1772496007000-CreateCommentsTable.ts
+++ b/src/migrations/1772496007000-CreateCommentsTable.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class CreateCommentsTable1772496002000 implements MigrationInterface {
-  name = 'CreateCommentsTable1772496002000';
+export class CreateCommentsTable1772496007000 implements MigrationInterface {
+  name = 'CreateCommentsTable1772496007000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`

--- a/src/migrations/1772496008000-CreateLikesTable.ts
+++ b/src/migrations/1772496008000-CreateLikesTable.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class CreateLikesTable1772496003000 implements MigrationInterface {
-  name = 'CreateLikesTable1772496003000';
+export class CreateLikesTable1772496008000 implements MigrationInterface {
+  name = 'CreateLikesTable1772496008000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`

--- a/src/report/dto/create-report.dto.ts
+++ b/src/report/dto/create-report.dto.ts
@@ -1,30 +1,13 @@
 import {
   IsEnum,
   IsNotEmpty,
-  IsNumber,
   IsObject,
   IsOptional,
   IsString,
-  IsUrl,
-  Max,
-  Min,
 } from 'class-validator';
 import { HazardLevel } from '../entities/report.entity';
 
 export class CreateReportDto {
-  @IsUrl()
-  imageUrl: string;
-
-  @IsNumber()
-  @Min(-90)
-  @Max(90)
-  latitude: number;
-
-  @IsNumber()
-  @Min(-180)
-  @Max(180)
-  longitude: number;
-
   @IsString()
   @IsNotEmpty()
   hazardType: string;

--- a/src/report/entities/report.entity.ts
+++ b/src/report/entities/report.entity.ts
@@ -7,8 +7,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
-import { Comment } from '../../comment/entities/comment.entity';
-import { Like } from '../../like/entities/like.entity';
+import { Image } from '../../image/entities/image.entity';
 import { User } from '../../user/entities/user.entity';
 
 export enum HazardLevel {
@@ -24,23 +23,6 @@ export class Report {
 
   @Column()
   userId: string;
-
-  @Column()
-  imageUrl: string;
-
-  @Column('decimal', { precision: 10, scale: 7 })
-  latitude: number;
-
-  @Column('decimal', { precision: 10, scale: 7 })
-  longitude: number;
-
-  @Column({
-    type: 'geometry',
-    spatialFeatureType: 'Point',
-    srid: 4326,
-    nullable: true,
-  })
-  location: string;
 
   @Column()
   hazardType: string;
@@ -63,11 +45,8 @@ export class Report {
   @ManyToOne(() => User, (user) => user.reports)
   user: User;
 
-  @OneToMany(() => Comment, (comment) => comment.report)
-  comments: Comment[];
-
-  @OneToMany(() => Like, (like) => like.report)
-  likes: Like[];
+  @OneToMany(() => Image, (image) => image.report)
+  images: Image[];
 
   likeCount: number;
   commentCount: number;

--- a/src/report/entities/report.entity.ts
+++ b/src/report/entities/report.entity.ts
@@ -4,10 +4,12 @@ import {
   Entity,
   ManyToOne,
   OneToMany,
+  OneToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { Image } from '../../image/entities/image.entity';
+import { Marker } from '../../marker/entities/marker.entity';
 import { User } from '../../user/entities/user.entity';
 
 export enum HazardLevel {
@@ -47,6 +49,9 @@ export class Report {
 
   @OneToMany(() => Image, (image) => image.report)
   images: Image[];
+
+  @OneToOne(() => Marker, (marker) => marker.report)
+  marker: Marker;
 
   likeCount: number;
   commentCount: number;

--- a/src/report/report.service.spec.ts
+++ b/src/report/report.service.spec.ts
@@ -8,10 +8,6 @@ import { CreateReportDto, GetReportsQueryDto, UpdateReportDto } from './dto';
 const mockReport = {
   id: 'report-uuid',
   userId: 'user-uuid',
-  imageUrl: 'https://example.com/image.jpg',
-  latitude: 37.5665,
-  longitude: 126.978,
-  location: null,
   hazardType: '도로파손',
   hazardLevel: HazardLevel.HIGH,
   description: '도로에 큰 구멍이 있습니다.',
@@ -19,21 +15,20 @@ const mockReport = {
   createdAt: new Date('2024-01-01'),
   updatedAt: new Date('2024-01-01'),
   user: null,
-  comments: [],
-  likes: [],
 } as unknown as Report;
 
 describe('ReportService', () => {
   let service: ReportService;
 
-  // QueryBuilder mock — 메서드 체이닝 지원
   const mockQueryBuilder = {
     insert: jest.fn().mockReturnThis(),
     into: jest.fn().mockReturnThis(),
     values: jest.fn().mockReturnThis(),
-    setParameters: jest.fn().mockReturnThis(),
     returning: jest.fn().mockReturnThis(),
     execute: jest.fn(),
+    // innerJoin, leftJoin 추가 — findNearby/findOne에서 marker 조인에 사용
+    innerJoin: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
     select: jest.fn().mockReturnThis(),
     addSelect: jest.fn().mockReturnThis(),
     loadRelationCountAndMap: jest.fn().mockReturnThis(),
@@ -65,18 +60,19 @@ describe('ReportService', () => {
 
     service = module.get<ReportService>(ReportService);
     jest.clearAllMocks();
-    // QueryBuilder mock 초기화 (ReturnThis가 clearAllMocks로 지워지므로 재설정)
-    mockQueryBuilder.insert.mockReturnThis();
-    mockQueryBuilder.into.mockReturnThis();
-    mockQueryBuilder.values.mockReturnThis();
-    mockQueryBuilder.setParameters.mockReturnThis();
-    mockQueryBuilder.returning.mockReturnThis();
-    mockQueryBuilder.select.mockReturnThis();
-    mockQueryBuilder.addSelect.mockReturnThis();
-    mockQueryBuilder.loadRelationCountAndMap.mockReturnThis();
-    mockQueryBuilder.where.mockReturnThis();
-    mockQueryBuilder.andWhere.mockReturnThis();
-    mockQueryBuilder.orderBy.mockReturnThis();
+    mockReportRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.insert.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.into.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.values.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.returning.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.innerJoin.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.leftJoin.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.select.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.addSelect.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.loadRelationCountAndMap.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.where.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.andWhere.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.orderBy.mockReturnValue(mockQueryBuilder);
   });
 
   // ──────────────────────────────────────────────
@@ -84,9 +80,6 @@ describe('ReportService', () => {
   // ──────────────────────────────────────────────
   describe('create', () => {
     const createDto: CreateReportDto = {
-      imageUrl: 'https://example.com/image.jpg',
-      latitude: 37.5665,
-      longitude: 126.978,
       hazardType: '도로파손',
       hazardLevel: HazardLevel.HIGH,
       description: '도로에 큰 구멍이 있습니다.',
@@ -103,10 +96,9 @@ describe('ReportService', () => {
       expect(mockReportRepository.createQueryBuilder).toHaveBeenCalled();
       expect(mockQueryBuilder.insert).toHaveBeenCalled();
       expect(mockQueryBuilder.into).toHaveBeenCalledWith(Report);
-      expect(mockQueryBuilder.setParameters).toHaveBeenCalledWith({
-        longitude: createDto.longitude,
-        latitude: createDto.latitude,
-      });
+      expect(mockQueryBuilder.values).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-uuid' }),
+      );
       expect(mockQueryBuilder.returning).toHaveBeenCalledWith('id');
       expect(mockReportRepository.findOne).toHaveBeenCalledWith({
         where: { id: 'report-uuid' },
@@ -210,11 +202,11 @@ describe('ReportService', () => {
 
       expect(mockQueryBuilder.loadRelationCountAndMap).toHaveBeenCalledWith(
         'report.likeCount',
-        'report.likes',
+        'marker.likes',
       );
       expect(mockQueryBuilder.loadRelationCountAndMap).toHaveBeenCalledWith(
         'report.commentCount',
-        'report.comments',
+        'marker.comments',
       );
     });
   });
@@ -252,11 +244,11 @@ describe('ReportService', () => {
 
       expect(mockQueryBuilder.loadRelationCountAndMap).toHaveBeenCalledWith(
         'report.likeCount',
-        'report.likes',
+        'marker.likes',
       );
       expect(mockQueryBuilder.loadRelationCountAndMap).toHaveBeenCalledWith(
         'report.commentCount',
-        'report.comments',
+        'marker.comments',
       );
     });
   });

--- a/src/report/report.service.ts
+++ b/src/report/report.service.ts
@@ -22,16 +22,11 @@ export class ReportService {
       .into(Report)
       .values({
         userId,
-        imageUrl: dto.imageUrl,
-        latitude: dto.latitude,
-        longitude: dto.longitude,
-        location: () => `ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)`,
         hazardType: dto.hazardType,
         hazardLevel: dto.hazardLevel,
         description: dto.description,
         ...(dto.aiRawResult && { aiRawResult: dto.aiRawResult }),
       })
-      .setParameters({ longitude: dto.longitude, latitude: dto.latitude })
       .returning('id')
       .execute();
 
@@ -44,23 +39,21 @@ export class ReportService {
   async findNearby(query: GetReportsQueryDto): Promise<Report[]> {
     const qb = this.reportRepository
       .createQueryBuilder('report')
+      .innerJoin('report.marker', 'marker')
       .select([
         'report.id',
         'report.userId',
-        'report.imageUrl',
-        'report.latitude',
-        'report.longitude',
         'report.hazardType',
         'report.hazardLevel',
         'report.description',
         'report.createdAt',
         'report.updatedAt',
       ])
-      .loadRelationCountAndMap('report.likeCount', 'report.likes')
-      .loadRelationCountAndMap('report.commentCount', 'report.comments')
+      .loadRelationCountAndMap('report.likeCount', 'marker.likes')
+      .loadRelationCountAndMap('report.commentCount', 'marker.comments')
       .where(
         `ST_DWithin(
-          report.location::geography,
+          marker.location::geography,
           ST_SetSRID(ST_MakePoint(:lng, :lat), 4326)::geography,
           :radius
         )`,
@@ -80,20 +73,18 @@ export class ReportService {
   async findOne(id: string): Promise<Report> {
     const report = await this.reportRepository
       .createQueryBuilder('report')
+      .leftJoin('report.marker', 'marker')
       .select([
         'report.id',
         'report.userId',
-        'report.imageUrl',
-        'report.latitude',
-        'report.longitude',
         'report.hazardType',
         'report.hazardLevel',
         'report.description',
         'report.createdAt',
         'report.updatedAt',
       ])
-      .loadRelationCountAndMap('report.likeCount', 'report.likes')
-      .loadRelationCountAndMap('report.commentCount', 'report.comments')
+      .loadRelationCountAndMap('report.likeCount', 'marker.likes')
+      .loadRelationCountAndMap('report.commentCount', 'marker.comments')
       .where('report.id = :id', { id })
       .getOne();
 

--- a/src/safety-mungo-report/entities/safety-mungo-report.entity.ts
+++ b/src/safety-mungo-report/entities/safety-mungo-report.entity.ts
@@ -4,7 +4,7 @@ import { Marker } from '../../marker/entities/marker.entity';
 @Entity('safety_mungo_reports')
 export class SafetyMungoReport {
   @PrimaryColumn()
-  externalReportId: string;
+  id: string;
 
   @Column({ nullable: true })
   externalId: string | null;

--- a/src/safety-mungo-report/entities/safety-mungo-report.entity.ts
+++ b/src/safety-mungo-report/entities/safety-mungo-report.entity.ts
@@ -1,4 +1,5 @@
-import { Column, Entity, PrimaryColumn } from 'typeorm';
+import { Column, Entity, OneToOne, PrimaryColumn } from 'typeorm';
+import { Marker } from '../../marker/entities/marker.entity';
 
 @Entity('safety_mungo_reports')
 export class SafetyMungoReport {
@@ -25,4 +26,7 @@ export class SafetyMungoReport {
 
   @Column({ type: 'timestamp', nullable: true })
   syncedAt: Date | null;
+
+  @OneToOne(() => Marker, (marker) => marker.safetyMungoReport)
+  marker: Marker;
 }

--- a/src/safety-mungo-report/entities/safety-mungo-report.entity.ts
+++ b/src/safety-mungo-report/entities/safety-mungo-report.entity.ts
@@ -1,0 +1,28 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity('safety_mungo_reports')
+export class SafetyMungoReport {
+  @PrimaryColumn()
+  externalReportId: string;
+
+  @Column({ nullable: true })
+  externalId: string | null;
+
+  @Column({ nullable: true })
+  spotName: string | null;
+
+  @Column({ nullable: true })
+  category: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  description: string | null;
+
+  @Column({ nullable: true })
+  origin: string | null;
+
+  @Column({ type: 'date', nullable: true })
+  occurenceDate: Date | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  syncedAt: Date | null;
+}

--- a/src/safety-mungo-report/entities/safety-mungo-report.entity.ts
+++ b/src/safety-mungo-report/entities/safety-mungo-report.entity.ts
@@ -22,7 +22,7 @@ export class SafetyMungoReport {
   origin: string | null;
 
   @Column({ type: 'date', nullable: true })
-  occurenceDate: Date | null;
+  occurrenceDate: Date | null;
 
   @Column({ type: 'timestamp', nullable: true })
   syncedAt: Date | null;

--- a/src/safety-mungo-report/safety-mungo-report.module.ts
+++ b/src/safety-mungo-report/safety-mungo-report.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SafetyMungoReport } from './entities/safety-mungo-report.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SafetyMungoReport])],
+})
+export class SafetyMungoReportModule {}


### PR DESCRIPTION
## 관련 이슈

- closes #19 

## 작업 내용

<!-- 무엇을 했는지 -->

03.05 회의에서 제안된 논의사항을 근거로 reports 중심이었던 DB 구조를 markers 중심 구조로 재설계했습니다. 사용자 신고 또는 안전신문고 외부 데이터가 생성된 뒤 마커가 생성되며, 댓글/공감은 마커를 직접 참조합니다.

## 변경 사항

- [x] markers 엔티티 및 마이그레이션 생성(reportId, safetyMungoReportId FK(UNIQUE) 보유, hazardLevel nullable (안전신문고 출처는 등급 정보 없음))  
- [x] safety_mungo_reports 엔티티 및 마이그레이션 생성  
- [x] reports 스키마 수정 (imageUrl, latitude, longitude, location 제거 / images 테이블 1:N 연결로 대체 / comments, likes 관계 제거)
- [x] images 스키마 수정 (PK SERIAL → UUID, 테이블명 image → images, reportId FK 추가, size 타입 BIGINT → INTEGER)  
- [x] comments FK 변경 (reportId → markerId (ON DELETE CASCADE 대상 변경))  
- [x] likes FK 변경 (reportId → markerId, UNIQUE 제약 (reportId, userId) → (markerId, userId))  
- [X] FK 의존성에 맞게 마이그레이션 실행 순서 재정렬 `users → reports → safety_mungo_reports → markers → images → comments → likes`  

## 테스트

- [X] 로컬에서 테스트 완료
- [X] 기존 기능 정상 동작 확인

## 리뷰어에게

<!-- 특별히 봐줬으면 하는 부분, 논의할 사항 -->
<img width="1000" height="1262" alt="image" src="https://github.com/user-attachments/assets/37cebdee-b501-4ce7-99e3-6877d0af1d4b" />

- 통일성을 위해 image테이블명을 images로 변경하고 id로 serial이 아니라 uuid로 변경했습니다. (기존에 제가 구현했던 다른 테이블들은 열거 공격이나 보안적인 부분을 우려해서 uuid로 했는데 프로젝트 규모상 너무 과했나 싶기도 합니다. 일단 통일했습니다!)  
