### PR TITLE
fix: marker 모듈 swagger 응답 dto 누락

### DIFF
--- a/src/marker/dto/index.ts
+++ b/src/marker/dto/index.ts
@@ -1,3 +1,4 @@
 export * from './create-marker.dto';
 export * from './get-markers-query.dto';
+export * from './marker-response.dto';
 export * from './update-marker.dto';

--- a/src/marker/dto/marker-response.dto.ts
+++ b/src/marker/dto/marker-response.dto.ts
@@ -1,0 +1,132 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { HazardLevel } from '../../report/entities/report.entity';
+import { MarkerSource } from '../entities/marker.entity';
+
+export class ReportInMarkerDto {
+  @ApiProperty({
+    description: '신고 ID (UUID)',
+    example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: '신고자 사용자 ID (UUID)',
+    example: 'f0e1d2c3-b4a5-6789-fedc-ba0987654321',
+  })
+  userId: string;
+
+  @ApiProperty({
+    description: '신고 내용',
+    example: '도로에 포트홀이 있습니다.',
+  })
+  description: string;
+
+  @ApiProperty({
+    description: 'AI 분석 원본 결과 (nullable)',
+    nullable: true,
+    required: false,
+  })
+  aiRawResult: object | null;
+
+  @ApiProperty({
+    description: '생성 시각 (ISO 8601)',
+    example: '2026-03-11T09:00:00.000Z',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    description: '수정 시각 (ISO 8601)',
+    example: '2026-03-11T10:30:00.000Z',
+  })
+  updatedAt: Date;
+}
+
+export class SafetyMungoReportInMarkerDto {
+  @ApiProperty({
+    description: '안전신문고 리포트 ID (unique_key)',
+    example: 'a3f8c2e1b9d4...',
+  })
+  id: string;
+
+  @ApiProperty({ description: '장소명', nullable: true, required: false })
+  spotName: string | null;
+
+  @ApiProperty({
+    description: '신고 카테고리',
+    nullable: true,
+    required: false,
+  })
+  category: string | null;
+
+  @ApiProperty({ description: '신고 내용', nullable: true, required: false })
+  description: string | null;
+
+  @ApiProperty({ description: '출처 기관', nullable: true, required: false })
+  origin: string | null;
+
+  @ApiProperty({
+    description: '발생 일자',
+    nullable: true,
+    required: false,
+    example: '2025-10-01',
+  })
+  occurrenceDate: Date | null;
+}
+
+export class MarkerResponseDto {
+  @ApiProperty({
+    description: '마커 ID (UUID)',
+    example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  })
+  id: string;
+
+  @ApiProperty({ description: '마커 출처', enum: MarkerSource })
+  source: MarkerSource;
+
+  @ApiProperty({ description: '위도', example: 37.4971 })
+  latitude: number;
+
+  @ApiProperty({ description: '경도', example: 126.9568 })
+  longitude: number;
+
+  @ApiProperty({ description: '위험 유형', example: '도로파손' })
+  hazardType: string;
+
+  @ApiProperty({
+    description: '위험 등급 (nullable)',
+    enum: HazardLevel,
+    nullable: true,
+    required: false,
+  })
+  hazardLevel: HazardLevel | null;
+
+  @ApiProperty({
+    description: '생성 시각 (ISO 8601)',
+    example: '2026-03-11T09:00:00.000Z',
+  })
+  createdAt: Date;
+
+  @ApiProperty({ description: '좋아요 수', example: 5 })
+  likeCount: number;
+
+  @ApiProperty({ description: '댓글 수', example: 3 })
+  commentCount: number;
+}
+
+export class MarkerDetailResponseDto extends MarkerResponseDto {
+  @ApiProperty({
+    description: 'REPORT 타입일 때의 신고 상세 (nullable)',
+    type: ReportInMarkerDto,
+    nullable: true,
+    required: false,
+  })
+  report: ReportInMarkerDto | null;
+
+  @ApiProperty({
+    description: 'SAFETY_MUNGO 타입일 때의 안전신문고 상세 (nullable)',
+    type: SafetyMungoReportInMarkerDto,
+    nullable: true,
+    required: false,
+  })
+  safetyMungoReport: SafetyMungoReportInMarkerDto | null;
+}

--- a/src/marker/marker.controller.ts
+++ b/src/marker/marker.controller.ts
@@ -15,13 +15,21 @@ import {
 import { Request } from 'express';
 import {
   ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiOkResponse,
   ApiOperation,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { User } from '../user/entities/user.entity';
-import { CreateMarkerDto, GetMarkersQueryDto, UpdateMarkerDto } from './dto';
+import {
+  CreateMarkerDto,
+  GetMarkersQueryDto,
+  MarkerDetailResponseDto,
+  MarkerResponseDto,
+  UpdateMarkerDto,
+} from './dto';
 import { MarkerService } from './marker.service';
 
 @ApiTags('Markers')
@@ -33,7 +41,10 @@ export class MarkerController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: '마커 생성 (신고 + 마커 동시 생성)' })
-  @ApiResponse({ status: 201, description: '마커 생성 성공' })
+  @ApiCreatedResponse({
+    type: MarkerDetailResponseDto,
+    description: '마커 생성 성공',
+  })
   @ApiResponse({ status: 400, description: '잘못된 요청 (유효성 검증 실패)' })
   @ApiResponse({ status: 401, description: '인증 필요' })
   create(@Body() dto: CreateMarkerDto, @Req() req: Request & { user: User }) {
@@ -42,7 +53,7 @@ export class MarkerController {
 
   @Get()
   @ApiOperation({ summary: '반경 내 마커 목록 조회' })
-  @ApiResponse({ status: 200, description: '마커 목록 반환' })
+  @ApiOkResponse({ type: [MarkerResponseDto], description: '마커 목록 반환' })
   @ApiResponse({
     status: 400,
     description: '잘못된 요청 (좌표/반경 유효성 실패)',
@@ -53,7 +64,10 @@ export class MarkerController {
 
   @Get(':id')
   @ApiOperation({ summary: '마커 단건 조회' })
-  @ApiResponse({ status: 200, description: '마커 상세 반환' })
+  @ApiOkResponse({
+    type: MarkerDetailResponseDto,
+    description: '마커 상세 반환',
+  })
   @ApiResponse({ status: 404, description: '마커 없음' })
   findOne(@Param('id') id: string) {
     return this.markerService.findOne(id);
@@ -63,7 +77,10 @@ export class MarkerController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: '마커 수정 (REPORT 타입, 본인만)' })
-  @ApiResponse({ status: 200, description: '수정된 마커 반환' })
+  @ApiOkResponse({
+    type: MarkerDetailResponseDto,
+    description: '수정된 마커 반환',
+  })
   @ApiResponse({ status: 400, description: '잘못된 요청' })
   @ApiResponse({ status: 401, description: '인증 필요' })
   @ApiResponse({


### PR DESCRIPTION
## 관련 이슈

closes #28

## 작업 내용

marker 모듈 API 엔드포인트에 타입이 명시된 Swagger 응답 DTO를 추가했습니다.

## 변경 사항

- [x] `src/marker/dto/marker-response.dto.ts` 추가 (`MarkerResponseDto`, `MarkerDetailResponseDto`, `ReportInMarkerDto`, `SafetyMungoReportInMarkerDto`)
- [x] `src/marker/dto/index.ts` export 추가
- [x] `src/marker/marker.controller.ts` `@ApiCreatedResponse`, `@ApiOkResponse`에 type 지정

## 테스트

- [ ] 로컬에서 테스트 완료
- [ ] 기존 기능 정상 동작 확인

## 리뷰어에게

- `MarkerResponseDto`는 목록 조회(GET /) 응답, `MarkerDetailResponseDto`는 단건/생성/수정 응답에 사용
- `likeCount`, `commentCount`는 `loadRelationCountAndMap`으로 런타임에 주입되는 가상 필드이므로 DTO에서만 선언